### PR TITLE
Use singer.utils.parse_args

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     py_modules=['tap_exacttarget'],
     install_requires=[
         'funcy==1.9.1',
-        'singer-python>=3.5.0',
+        'singer-python>=5.0.6',
         'python-dateutil==2.6.0',
         'voluptuous==0.10.5',
         'pyjwt>=0.1.9',

--- a/tap_exacttarget/__init__.py
+++ b/tap_exacttarget/__init__.py
@@ -140,20 +140,16 @@ def do_sync(args):
     save_state(state)
 
 
+@utils.handle_top_exception(LOGGER)
 def main():
     args = utils.parse_args(REQUIRED_CONFIG_KEYS)
 
-    try:
-        if args.discover:
-            do_discover(args)
-        elif args.properties:
-            do_sync(args)
-        else:
-            LOGGER.info("No properties were selected")
-    except Exception as exception:
-        LOGGER.critical(exception)
-        raise exception
-
+    if args.discover:
+        do_discover(args)
+    elif args.properties:
+        do_sync(args)
+    else:
+        LOGGER.info("No properties were selected")
 
 if __name__ == '__main__':
     main()

--- a/tap_exacttarget/state.py
+++ b/tap_exacttarget/state.py
@@ -1,4 +1,3 @@
-import json
 from dateutil.parser import parse
 
 import singer
@@ -53,15 +52,3 @@ def save_state(state):
     LOGGER.info('Updating state.')
 
     singer.write_state(state)
-
-
-def load_state(filename):
-    if filename is None:
-        return {}
-
-    try:
-        with open(filename) as handle:
-            return json.load(handle)
-    except:
-        LOGGER.fatal("Failed to decode state file. Is it valid json?")
-        raise RuntimeError


### PR DESCRIPTION
Motivation
----------

We were using a misconfigured arg parser. `singer-python` provides a
default one. There was no use of the `--select-all` option that I could
find.

**Note:** ~~Must wait on https://github.com/singer-io/singer-python/pull/67 being released.~~ Actually I lied. Because this no longer needs the custom option there's no dependency between this and that PR.