### PR TITLE
implement laziness correctly in partition_all, use it

### DIFF
--- a/tap_exacttarget/endpoints/list_subscribers.py
+++ b/tap_exacttarget/endpoints/list_subscribers.py
@@ -119,8 +119,7 @@ class ListSubscriberDataAccessObject(DataAccessObject):
             if self.replicate_subscriber:
                 subscriber_dao.write_schema()
 
-            for list_subscribers_batch in partition_all(list(stream),
-                                                        batch_size):
+            for list_subscribers_batch in partition_all(stream, batch_size):
                 for list_subscriber in list_subscribers_batch:
                     list_subscriber = self.filter_keys_and_parse(
                         list_subscriber)

--- a/tap_exacttarget/util.py
+++ b/tap_exacttarget/util.py
@@ -3,9 +3,16 @@ import suds
 
 
 def partition_all(collection, chunk_size):
-    return (collection[index:(index + chunk_size)]
-            for index
-            in range(0, len(collection), chunk_size))
+    to_yield = []
+
+    for item in collection:
+        to_yield.append(item)
+
+        if len(to_yield) >= chunk_size:
+            yield to_yield
+            to_yield = []
+
+    yield to_yield
 
 
 def sudsobj_to_dict(obj):


### PR DESCRIPTION
A mutual client was seeing errors in ListSubscriber -- the tap was just pulling data continuously until it reached an OOM error. I fixed the partition_all function to be a generator instead of just statically building a list, and now the tap interleaves pulling ListSubscriber data and writing it to Stitch. I haven't explicitly tested that it discards data as it moves forward in the generator, but my basic understanding of generators makes me think that this works correctly. Let me know if you think differently!