### PR TITLE
fix pagination: paginate up to the current second ...

### DIFF
--- a/tap_exacttarget/endpoints/data_extensions.py
+++ b/tap_exacttarget/endpoints/data_extensions.py
@@ -5,7 +5,7 @@ from funcy import set_in, update_in, merge
 
 from tap_exacttarget.client import request, request_from_cursor
 from tap_exacttarget.dao import DataAccessObject
-from tap_exacttarget.pagination import get_date_page, before_today, \
+from tap_exacttarget.pagination import get_date_page, before_now, \
     increment_date
 from tap_exacttarget.state import incorporate, save_state, \
     get_last_record_value_for_table
@@ -250,7 +250,7 @@ class DataExtensionDataAccessObject(DataAccessObject):
         parent_extension = next(parent_result)
         parent_category_id = parent_extension.CategoryID
 
-        while before_today(start) or replication_key is None:
+        while before_now(start) or replication_key is None:
             self._replicate(
                 customer_key,
                 keys,

--- a/tap_exacttarget/endpoints/events.py
+++ b/tap_exacttarget/endpoints/events.py
@@ -3,7 +3,7 @@ import singer
 
 from tap_exacttarget.client import request
 from tap_exacttarget.dao import DataAccessObject
-from tap_exacttarget.pagination import get_date_page, before_today, \
+from tap_exacttarget.pagination import get_date_page, before_now, \
     increment_date
 from tap_exacttarget.schemas import SUBSCRIBER_KEY_FIELD, with_properties
 from tap_exacttarget.state import incorporate, save_state, \
@@ -64,7 +64,7 @@ class EventDataAccessObject(DataAccessObject):
 
             end = increment_date(start, unit)
 
-            while before_today(start):
+            while before_now(start):
                 LOGGER.info("Fetching {} from {} to {}"
                             .format(event_name, start, end))
 

--- a/tap_exacttarget/endpoints/list_subscribers.py
+++ b/tap_exacttarget/endpoints/list_subscribers.py
@@ -4,7 +4,7 @@ import singer
 from tap_exacttarget.client import request
 from tap_exacttarget.dao import DataAccessObject
 from tap_exacttarget.endpoints.subscribers import SubscriberDataAccessObject
-from tap_exacttarget.pagination import get_date_page, before_today, \
+from tap_exacttarget.pagination import get_date_page, before_now, \
     increment_date
 from tap_exacttarget.schemas import ID_FIELD, CUSTOM_PROPERTY_LIST, \
     CREATED_DATE_FIELD, OBJECT_ID_FIELD, MODIFIED_DATE_FIELD, \
@@ -106,7 +106,7 @@ class ListSubscriberDataAccessObject(DataAccessObject):
 
         all_subscribers_list = self._get_all_subscribers_list()
 
-        while before_today(start):
+        while before_now(start):
             stream = request('ListSubscriber',
                              FuelSDK.ET_List_Subscriber,
                              self.auth_stub,

--- a/tap_exacttarget/pagination.py
+++ b/tap_exacttarget/pagination.py
@@ -1,13 +1,15 @@
 import datetime
+import singer
+
 from tap_exacttarget.filters import between
 
-
+LOGGER = singer.get_logger()
 DATE_FORMAT = "%Y-%m-%dT%H:%M:%SZ"
 
 
-def before_today(date_value):
-    return (datetime.datetime.strptime(date_value, DATE_FORMAT).date() <=
-            datetime.datetime.today().date())
+def before_now(date_value):
+    return (datetime.datetime.strptime(date_value, DATE_FORMAT) <=
+            datetime.datetime.utcnow())
 
 
 def increment_date(date_value, unit=None):

--- a/tap_exacttarget/state.py
+++ b/tap_exacttarget/state.py
@@ -1,8 +1,11 @@
 from dateutil.parser import parse
 
+import datetime
 import singer
 
 from voluptuous import Schema, Required
+
+from tap_exacttarget.pagination import DATE_FORMAT
 
 LOGGER = singer.get_logger()
 
@@ -17,9 +20,14 @@ STATE_SCHEMA = Schema({
 
 
 def get_last_record_value_for_table(state, table):
-    return state.get('bookmarks', {}) \
-                .get(table, {}) \
-                .get('last_record')
+    raw = state.get('bookmarks', {}) \
+               .get(table, {}) \
+               .get('last_record')
+
+    date_obj = datetime.datetime.strptime(raw, DATE_FORMAT)
+    date_obj = date_obj - datetime.timedelta(days=1)
+
+    return date_obj.strftime(DATE_FORMAT)
 
 
 def incorporate(state, table, field, value):


### PR DESCRIPTION
... not until the end of today. roll back by one day when starting replication.

this was a relic of when we paginated everything by day. since we paginate events by minute now, this pagination strategy doesn't work at all.