### PR TITLE
check if start date is None before parsing it

### DIFF
--- a/tap_exacttarget/state.py
+++ b/tap_exacttarget/state.py
@@ -24,6 +24,9 @@ def get_last_record_value_for_table(state, table):
                .get(table, {}) \
                .get('last_record')
 
+    if raw is None:
+        return None
+
     date_obj = datetime.datetime.strptime(raw, DATE_FORMAT)
     date_obj = date_obj - datetime.timedelta(days=1)
 


### PR DESCRIPTION
I introduced a nasty bug into this code where an empty state (`{}`) creates an exception for the tap. This fixes it.

There are null checks in place at all of the endpoints that call this function.