### PR TITLE
skip empty subscriber batches

### DIFF
--- a/tap_exacttarget/endpoints/subscribers.py
+++ b/tap_exacttarget/endpoints/subscribers.py
@@ -125,6 +125,9 @@ class SubscriberDataAccessObject(DataAccessObject):
         pass
 
     def pull_subscribers_batch(self, subscriber_keys):
+        if not subscriber_keys:
+            return
+
         table = self.__class__.TABLE
         stream = request('Subscriber', FuelSDK.ET_Subscriber, self.auth_stub, {
             'Property': 'SubscriberKey',


### PR DESCRIPTION
We can just skip empty batches of subscribers, no need to try to replicate them.