### PR TITLE
exacttarget does not accept a list of one subscriberkey

### DIFF
--- a/tap_exacttarget/__init__.py
+++ b/tap_exacttarget/__init__.py
@@ -66,7 +66,7 @@ def do_discover(args):
 
         catalog += stream_accessor.generate_catalog()
 
-    print(json.dumps({'streams': catalog}))
+    print(json.dumps({'streams': catalog}, indent=4))
 
 
 def _is_selected(catalog_entry):

--- a/tap_exacttarget/endpoints/subscribers.py
+++ b/tap_exacttarget/endpoints/subscribers.py
@@ -129,11 +129,27 @@ class SubscriberDataAccessObject(DataAccessObject):
             return
 
         table = self.__class__.TABLE
-        stream = request('Subscriber', FuelSDK.ET_Subscriber, self.auth_stub, {
-            'Property': 'SubscriberKey',
-            'SimpleOperator': 'IN',
-            'Value': subscriber_keys
-        })
+        _filter = {}
+
+        if len(subscriber_keys) == 1:
+            _filter = {
+                'Property': 'SubscriberKey',
+                'SimpleOperator': 'equals',
+                'Value': subscriber_keys[0]
+            }
+
+        elif len(subscriber_keys) > 1:
+            _filter = {
+                'Property': 'SubscriberKey',
+                'SimpleOperator': 'IN',
+                'Value': subscriber_keys
+            }
+        else:
+            LOGGER.info('Got empty set of subscriber keys, moving on')
+            return
+
+        stream = request(
+            'Subscriber', FuelSDK.ET_Subscriber, self.auth_stub, _filter)
 
         for subscriber in stream:
             subscriber = self.filter_keys_and_parse(subscriber)


### PR DESCRIPTION
ExactTarget doesn't accept IN filters with a list of length 1 -- so if there's only one subscriberkey to pull, we have to use an `equals` filter rather than `IN`