### PR TITLE
make all fields nullable

### DIFF
--- a/tap_exacttarget/endpoints/campaigns.py
+++ b/tap_exacttarget/endpoints/campaigns.py
@@ -12,25 +12,25 @@ class CampaignDataAccessObject(DataAccessObject):
 
     SCHEMA = with_properties({
         'id': {
-            'type': 'string',
+            'type': ['null', 'string'],
         },
         'createdDate': {
-            'type': 'string',
+            'type': ['null', 'string'],
         },
         'modifiedDate': {
-            'type': 'string',
+            'type': ['null', 'string'],
         },
         'name': {
-            'type': 'string',
+            'type': ['null', 'string'],
         },
         'description': {
-            'type': 'string',
+            'type': ['null', 'string'],
         },
         'campaignCode': {
-            'type': 'string',
+            'type': ['null', 'string'],
         },
         'color': {
-            'type': 'string',
+            'type': ['null', 'string'],
         }
     })
 

--- a/tap_exacttarget/endpoints/content_areas.py
+++ b/tap_exacttarget/endpoints/content_areas.py
@@ -56,30 +56,30 @@ class ContentAreaDataAccessObject(DataAccessObject):
             'description': 'Indicates font family used in content area',
         },
         'HasFontSize': {
-            'type': 'boolean',
+            'type': ['null', 'boolean'],
             'description': ('Indicates whether the content area includes '
                             'a specified font size or not'),
         },
         'ID': ID_FIELD,
         'IsBlank': {
-            'type': 'boolean',
+            'type': ['null', 'boolean'],
             'description': ('Indicates if specified content area '
                             'contains no content.'),
         },
         'IsDynamicContent': {
-            'type': 'boolean',
+            'type': ['null', 'boolean'],
             'description': ('Indicates if specific content area '
                             'contains dynamic content.'),
         },
         'IsLocked': {
-            'type': 'boolean',
+            'type': ['null', 'boolean'],
             'description': ('Indicates if specific email content area '
                             'within an Enterprise or Enterprise 2.0 '
                             'account is locked and cannot be changed by '
                             'subaccounts.'),
         },
         'IsSurvey': {
-            'type': 'boolean',
+            'type': ['null', 'boolean'],
             'description': ('Indicates whether a specific content area '
                             'contains survey questions.'),
         },

--- a/tap_exacttarget/endpoints/data_extensions.py
+++ b/tap_exacttarget/endpoints/data_extensions.py
@@ -78,12 +78,12 @@ class DataExtensionDataAccessObject(DataAccessObject):
                     'selected-by-default': False,
                     'properties': {
                         '_CustomObjectKey': {
-                            'type': 'string',
+                            'type': ['null', 'string'],
                             'description': ('Hidden auto-incrementing primary '
                                             'key for data extension rows.'),
                         },
                         'CategoryID': {
-                            'type': 'integer',
+                            'type': ['null', 'integer'],
                             'description': ('Specifies the identifier of the '
                                             'folder. (Taken from the parent '
                                             'data extension.)')

--- a/tap_exacttarget/endpoints/emails.py
+++ b/tap_exacttarget/endpoints/emails.py
@@ -34,7 +34,7 @@ class EmailDataAccessObject(DataAccessObject):
             'description': ('Contains information on content areas '
                             'included in an email message.'),
             'items': {
-                'type': 'integer'
+                'type': ['null', 'integer']
             }
         },
         'ContentCheckStatus': {
@@ -49,7 +49,7 @@ class EmailDataAccessObject(DataAccessObject):
             'description': ('Defines preferred email type.'),
         },
         'HasDynamicSubjectLine': {
-            'type': 'boolean',
+            'type': ['null', 'boolean'],
             'description': ('Indicates whether email message contains '
                             'a dynamic subject line.'),
         },
@@ -59,11 +59,11 @@ class EmailDataAccessObject(DataAccessObject):
         },
         'ID': ID_FIELD,
         'IsActive': {
-            'type': 'boolean',
+            'type': ['null', 'boolean'],
             'description': ('Specifies whether the object is active.')
         },
         'IsHTMLPaste': {
-            'type': 'boolean',
+            'type': ['null', 'boolean'],
             'description': ('Indicates whether email message was created '
                             'via pasted HTML.')
         },
@@ -90,7 +90,7 @@ class EmailDataAccessObject(DataAccessObject):
                             'message.'),
         },
         'SyncTextWithHTML': {
-            'type': 'boolean',
+            'type': ['null', 'boolean'],
             'description': ('Makes the text version of an email contain '
                             'the same content as the HTML version.'),
         },

--- a/tap_exacttarget/endpoints/events.py
+++ b/tap_exacttarget/endpoints/events.py
@@ -16,16 +16,16 @@ LOGGER = singer.get_logger()
 class EventDataAccessObject(DataAccessObject):
     SCHEMA = with_properties({
         'SendID': {
-            'type': 'integer',
+            'type': ['null', 'integer'],
             'description': 'Contains identifier for a specific send.',
         },
         'EventDate': {
-            'type': 'string',
+            'type': ['null', 'string'],
             'format': 'datetime',
             'description': 'Date when a tracking event occurred.',
         },
         'EventType': {
-            'type': 'string',
+            'type': ['null', 'string'],
             'description': 'The type of tracking event',
         },
         'SubscriberKey': SUBSCRIBER_KEY_FIELD,

--- a/tap_exacttarget/endpoints/folders.py
+++ b/tap_exacttarget/endpoints/folders.py
@@ -17,12 +17,12 @@ class FolderDataAccessObject(DataAccessObject):
 
     SCHEMA = with_properties({
         'AllowChildren': {
-            'type': 'boolean',
+            'type': ['null', 'boolean'],
             'description': ('Specifies whether a data folder can have '
                             'child data folders.'),
         },
         'ContentType': {
-            'type': 'string',
+            'type': ['null', 'string'],
             'description': ('Defines the type of content contained '
                             'within a folder.'),
         },

--- a/tap_exacttarget/endpoints/list_subscribers.py
+++ b/tap_exacttarget/endpoints/list_subscribers.py
@@ -46,7 +46,7 @@ class ListSubscriberDataAccessObject(DataAccessObject):
                             'subscriber resides on.'),
         },
         'Status': {
-            'type': 'string',
+            'type': ['null', 'string'],
             'description': ('Defines status of object. Status of '
                             'an address.'),
         },

--- a/tap_exacttarget/endpoints/lists.py
+++ b/tap_exacttarget/endpoints/lists.py
@@ -17,7 +17,7 @@ class ListDataAccessObject(DataAccessObject):
 
     SCHEMA = with_properties({
         'Category': {
-            'type': 'integer',
+            'type': ['null', 'integer'],
             'description': 'ID of the folder that an item is located in.',
         },
         'CreatedDate': CREATED_DATE_FIELD,

--- a/tap_exacttarget/endpoints/sends.py
+++ b/tap_exacttarget/endpoints/sends.py
@@ -15,24 +15,24 @@ class SendDataAccessObject(DataAccessObject):
     SCHEMA = with_properties({
         'CreatedDate': CREATED_DATE_FIELD,
         'EmailID': {
-            'type': 'integer',
+            'type': ['null', 'integer'],
             'description': ('Specifies the ID of an email message '
                             'associated with a send.'),
         },
         'EmailName': {
-            'type': 'string',
+            'type': ['null', 'string'],
             'description': ('Specifies the name of an email message '
                             'associated with a send.'),
         },
         'FromAddress': {
-            'type': 'string',
+            'type': ['null', 'string'],
             'description': ('Indicates From address associated with a '
                             'object. Deprecated for email send '
                             'definitions and triggered send '
                             'definitions.'),
         },
         'FromName': {
-            'type': 'string',
+            'type': ['null', 'string'],
             'description': ('Specifies the default email message From '
                             'Name. Deprecated for email send '
                             'definitions and triggered send '
@@ -40,7 +40,7 @@ class SendDataAccessObject(DataAccessObject):
         },
         'ID': ID_FIELD,
         'IsAlwaysOn': {
-            'type': 'boolean',
+            'type': ['null', 'boolean'],
             'description': ('Indicates whether the request can be '
                             'performed while the system is is '
                             'maintenance mode. A value of true '
@@ -48,32 +48,32 @@ class SendDataAccessObject(DataAccessObject):
                             'request.'),
         },
         'IsMultipart': {
-            'type': 'boolean',
+            'type': ['null', 'boolean'],
             'description': ('Indicates whether the email is sent with '
                             'Multipart/MIME enabled.'),
         },
         'ModifiedDate': MODIFIED_DATE_FIELD,
         'PartnerProperties': CUSTOM_PROPERTY_LIST,
         'SendDate': {
-            'type': 'string',
+            'type': ['null', 'string'],
             'format': 'date-time',
             'description': ('Indicates the date on which a send '
                             'occurred. Set this value to have a CST '
                             '(Central Standard Time) value.'),
         },
         'SentDate': {
-            'type': 'string',
+            'type': ['null', 'string'],
             'format': 'date-time',
             'description': ('Indicates date on which a send took '
                             'place.'),
         },
         'Status': {
-            'type': 'string',
+            'type': ['null', 'string'],
             'description': ('Defines status of object. Status of an '
                             'address.'),
         },
         'Subject': {
-            'type': 'string',
+            'type': ['null', 'string'],
             'description': ('Contains subject area information for '
                             'a message.'),
         }

--- a/tap_exacttarget/endpoints/subscribers.py
+++ b/tap_exacttarget/endpoints/subscribers.py
@@ -19,9 +19,9 @@ SCHEMA = with_properties({
         'items': {
             'type': 'object',
             'properties': {
-                'Address': {'type': 'string'},
-                'AddressType': {'type': 'string'},
-                'AddressStatus': {'type': 'string'}
+                'Address': {'type': ['null', 'string']},
+                'AddressType': {'type': ['null', 'string']},
+                'AddressStatus': {'type': ['null', 'string']}
             }
         }
     },
@@ -43,7 +43,7 @@ SCHEMA = with_properties({
         'type': 'array',
         'description': 'Defines list IDs a subscriber resides on.',
         'items': {
-            'type': 'string'
+            'type': ['null', 'string']
         }
     },
     'Locale': {
@@ -79,7 +79,7 @@ SCHEMA = with_properties({
         'description': 'Indicates the subscriber\'s modality status.',
     },
     'Status': {
-        'type': 'string',
+        'type': ['null', 'string'],
         'description': 'Defines status of object. Status of an address.',
     },
     'SubscriberKey': SUBSCRIBER_KEY_FIELD,

--- a/tap_exacttarget/schemas.py
+++ b/tap_exacttarget/schemas.py
@@ -14,14 +14,14 @@ CUSTOM_PROPERTY_LIST = {
     'items': {
         'type': 'object',
         'properties': {
-            'Name': {'type': 'string'},
+            'Name': {'type': ['null', 'string']},
             'Value': {'type': ['null', 'string']},
         }
     }
 }
 
 ID_FIELD = {
-    'type': 'integer',
+    'type': ['null', 'integer'],
     'description': ('Read-only legacy identifier for an object. Not '
                     'supported on all objects. Some objects use the '
                     'ObjectID property as the Marketing Cloud unique '
@@ -61,6 +61,6 @@ DESCRIPTION_FIELD = {
 }
 
 SUBSCRIBER_KEY_FIELD = {
-    'type': 'string',
+    'type': ['null', 'string'],
     'description': 'Identification of a specific subscriber.',
 }


### PR DESCRIPTION
On a recent run of the tap:

```
Failed validating 'type' in schema['properties']['FromName']:
    {'description': 'Specifies the default email message From Name. '
                    'Deprecated for email send definitions and triggered '
                    'send definitions.',
     'type': 'string'}

On instance['FromName']:
    None
```

Exacttarget's docs indicate that this field should always be a string, but looks like it can be null / missing. This branch makes all primitive type fields in this tap nullable.