### PR TITLE
pass time unit to data extension replicator (v1)

### DIFF
--- a/tap_exacttarget/endpoints/data_extensions.py
+++ b/tap_exacttarget/endpoints/data_extensions.py
@@ -275,6 +275,7 @@ class DataExtensionDataAccessObject(DataAccessObject):
                 partial=(replication_key is not None),
                 start=start,
                 end=end,
+                unit=unit,
                 replication_key=replication_key)
 
             if replication_key is None:


### PR DESCRIPTION
This branch fixes a bug where the data extension replicator uses the wrong time unit, and misses data.

Tested on a live account on a data extension where the bug was exhibited. Row counts match up after running with this fix.