### PR TITLE
pass time unit to data extension replicator (v0)

### DIFF
--- a/tap_exacttarget/endpoints/data_extensions.py
+++ b/tap_exacttarget/endpoints/data_extensions.py
@@ -235,6 +235,7 @@ class DataExtensionDataAccessObject(DataAccessObject):
                 partial=(replication_key is not None),
                 start=start,
                 end=end,
+                unit=unit,
                 replication_key=replication_key)
 
             if replication_key is None:


### PR DESCRIPTION
Identical to #16 , but for v0