### PR TITLE
Reduce bookmark rewind window

### DIFF
--- a/tap_exacttarget/state.py
+++ b/tap_exacttarget/state.py
@@ -28,7 +28,7 @@ def get_last_record_value_for_table(state, table):
         return None
 
     date_obj = datetime.datetime.strptime(raw, DATE_FORMAT)
-    date_obj = date_obj - datetime.timedelta(days=1)
+    date_obj = date_obj - datetime.timedelta(hours=6)
 
     return date_obj.strftime(DATE_FORMAT)
 


### PR DESCRIPTION
This reduces the bookmark rewind. When it is set at 24 hours and we run the tap in 1 hour intervals, we see the same data pass to us 24 times as it's set right now.