### PR TITLE
SubscriberKey should not be a required field

### DIFF
--- a/tap_exacttarget/endpoints/events.py
+++ b/tap_exacttarget/endpoints/events.py
@@ -36,7 +36,7 @@ class EventDataAccessObject(DataAccessObject):
     })
 
     TABLE = 'event'
-    KEY_PROPERTIES = ['SendID', 'EventType', 'SubscriberKey', 'EventDate']
+    KEY_PROPERTIES = ['SendID', 'EventType', 'EventDate']
 
     def sync_data(self):
         table = self.__class__.TABLE


### PR DESCRIPTION
`SubscriberKey` can be `nullable` as defined in https://github.com/singer-io/tap-exacttarget/blob/master/tap_exacttarget/endpoints/subscribers.py#L85-L90

Since `null` is a valid value for `SubscriberKey`, it should not be a required field. 

@luandy64 -- thoughts
