### PR TITLE
Adds BatchID and CorrelationID to events

### DIFF
--- a/tap_exacttarget/endpoints/events.py
+++ b/tap_exacttarget/endpoints/events.py
@@ -28,9 +28,17 @@ class EventDataAccessObject(DataAccessObject):
             'type': ['null', 'string'],
             'description': 'The type of tracking event',
         },
+        'BatchID': {
+            'type': ['null','integer'],
+            'description': 'Ties triggered send sent events to other events (like clicks and opens that occur at a later date and time)',
+        },
+        'CorrelationID': {
+            'type': ['null','string'],
+            'description': 'Identifies correlation of objects across several requests.',
+        },
         'URL': {
             'type': ['null','string'],
-            'description': 'URL that was clicked.'
+            'description': 'URL that was clicked.',
         },
         'SubscriberKey': SUBSCRIBER_KEY_FIELD,
     })


### PR DESCRIPTION
## What
Adds BatchID and CorrelationID to events

https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/sentevent.htm?search_text=SentEvent

## Why
Both of these should be present on all of the events. This should allow for better correlation of related events (i.e. click to send attribution)

## Open Questions
* Should these values be included in KEY_PROPERTIES?
* How can this change be tested?