### PR TITLE
fix: Error persisting data for table "event": missing SubscriberKey

### DIFF
--- a/tap_exacttarget/endpoints/events.py
+++ b/tap_exacttarget/endpoints/events.py
@@ -95,6 +95,13 @@ class EventDataAccessObject(DataAccessObject):
                                              'EventDate',
                                              event.get('EventDate'))
 
+                    if event.get('SubscriberKey') is None:
+                        LOGGER.info("SubscriberKey is Null so ignoring {} record with SendID: {} and EventDate: {}"
+                                    .format(event_name,
+                                            event.get('SendID'),
+                                            event.get('EventDate')))
+                        continue
+
                     singer.write_records(table, [event])
 
                 self.state = incorporate(self.state,


### PR DESCRIPTION
SubscriberKey From the API is sometimes null, so ignoring those records.

Fixes #26 