### PR TITLE
Filter records where SubscriberKey is NULL

### DIFF
--- a/tap_exacttarget/endpoints/events.py
+++ b/tap_exacttarget/endpoints/events.py
@@ -95,6 +95,13 @@ class EventDataAccessObject(DataAccessObject):
                                              'EventDate',
                                              event.get('EventDate'))
 
+                        if event.get('SubscriberKey') is None:
+                            LOGGER.info("SubscriberKey is NULL so ignoring {} record with SendID: {} and EventDate: {}"
+                                    .format(event_name,
+                                            event.get('SendID'),
+                                            event.get('EventDate')))
+                        continue
+
                     singer.write_records(table, [event])
 
                 self.state = incorporate(self.state,

--- a/tap_exacttarget/endpoints/events.py
+++ b/tap_exacttarget/endpoints/events.py
@@ -95,8 +95,8 @@ class EventDataAccessObject(DataAccessObject):
                                              'EventDate',
                                              event.get('EventDate'))
 
-                        if event.get('SubscriberKey') is None:
-                            LOGGER.info("SubscriberKey is NULL so ignoring {} record with SendID: {} and EventDate: {}"
+                    if event.get('SubscriberKey') is None:
+                        LOGGER.info("SubscriberKey is NULL so ignoring {} record with SendID: {} and EventDate: {}"
                                     .format(event_name,
                                             event.get('SendID'),
                                             event.get('EventDate')))


### PR DESCRIPTION
This addresses the issue where sometimes the ET API returns records where SubscriberKey is NULL. 

This supersedes https://github.com/singer-io/tap-exacttarget/pull/32 and https://github.com/singer-io/tap-exacttarget/pull/27