### PR TITLE
Provide a configurable batch size to reduce memory usage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,3 +102,5 @@ ENV/
 
 # Emacs
 .tramp_history
+config.json
+catalog.json

--- a/config.json.example
+++ b/config.json.example
@@ -3,6 +3,7 @@
     "client_secret": "",
     "start_date": "2014-01-01T00:00:00Z",
     "request_timeout": "900",
+    "batch_size": 2500,
 
     "pagination__sent_interval_unit": "minutes",
     "pagination__sent_interval_quantity": "10",

--- a/tap_exacttarget/endpoints/data_extensions.py
+++ b/tap_exacttarget/endpoints/data_extensions.py
@@ -60,7 +60,9 @@ class DataExtensionDataAccessObject(DataAccessObject):
             'DataExtension',
             FuelSDK.ET_DataExtension,
             self.auth_stub,
-            props=['CustomerKey', 'Name'])
+            props=['CustomerKey', 'Name'],
+            batch_size=self.config.get('batch_size', 2500)
+        )
 
         to_return = {}
 
@@ -200,7 +202,9 @@ class DataExtensionDataAccessObject(DataAccessObject):
                                                  start,
                                                  unit)
 
-        result = request_from_cursor('DataExtensionObject', cursor)
+        batch_size = self.config.get('batch_size', 2500)
+        result = request_from_cursor('DataExtensionObject', cursor,
+                                     batch_size=batch_size)
 
         for row in result:
             row = self.filter_keys_and_parse(row)

--- a/tap_exacttarget/endpoints/data_extensions.py
+++ b/tap_exacttarget/endpoints/data_extensions.py
@@ -61,7 +61,7 @@ class DataExtensionDataAccessObject(DataAccessObject):
             FuelSDK.ET_DataExtension,
             self.auth_stub,
             props=['CustomerKey', 'Name'],
-            batch_size=self.config.get('batch_size', 2500)
+            batch_size=int(self.config.get('batch_size', 2500))
         )
 
         to_return = {}
@@ -202,7 +202,7 @@ class DataExtensionDataAccessObject(DataAccessObject):
                                                  start,
                                                  unit)
 
-        batch_size = self.config.get('batch_size', 2500)
+        batch_size = int(self.config.get('batch_size', 2500))
         result = request_from_cursor('DataExtensionObject', cursor,
                                      batch_size=batch_size)
 

--- a/tap_exacttarget/fuel_overrides.py
+++ b/tap_exacttarget/fuel_overrides.py
@@ -1,0 +1,36 @@
+
+import FuelSDK
+
+"""
+This module overrides classes and methods deep inside of the FuelSDK module.
+We need to do this in order to specify the batch size for the getMoreRequests()
+method call. This is necessary because the default, 2500 records, consumes too
+much memory to be run in Stitch. If the Stitch memory limits are raised, or if
+there is a more native way to specify this configuration, then this tap should
+be modified to call into the getMoreRequests() method in the FuelSDK module.
+
+See: https://github.com/singer-io/tap-exacttarget/issues/25
+"""
+
+
+class TapExacttarget__ET_Continue(FuelSDK.rest.ET_Constructor):
+    def __init__(self, auth_stub, request_id, batch_size):
+        auth_stub.refresh_token()
+
+        ws_continueRequest = auth_stub.soap_client.factory.create('RetrieveRequest')
+        ws_continueRequest.ContinueRequest = request_id
+
+        # tap-exacttarget override: set batch size here
+        ws_continueRequest.Options.BatchSize = batch_size
+
+        response = auth_stub.soap_client.service.Retrieve(ws_continueRequest)
+
+        if response is not None:
+            super(TapExacttarget__ET_Continue, self).__init__(response)
+
+def tap_exacttarget__getMoreResults(cursor, batch_size=2500):
+    obj = TapExacttarget__ET_Continue(cursor.auth_stub, cursor.last_request_id, batch_size)
+    if obj is not None:
+        cursor.last_request_id = obj.request_id
+
+    return obj


### PR DESCRIPTION
fixes https://github.com/singer-io/tap-exacttarget/issues/25

Looks like there are a couple of reports in [#25](https://github.com/singer-io/tap-exacttarget/issues/25) of Stitch running out of memory while running this tap causing it to fail with a `-9` exit code. This PR adds a configurable `batch_size` parameter which controls the number of records fetched for each stream. When the batch size is set to a number like 100, or 1000, this tap uses considerably less memory than the default of 2500 records per batch.

I tried _really_ hard to make this work natively with the FuelSDK, but I encountered a couple of problems:
1. The `getMoreResults` method in the FuelSDK ignores the BatchSize option provided on the cursor object
2. There are serious logic errors in the FuelSDK codebase, like [this one](https://github.com/salesforce-marketingcloud/FuelSDK-Python/blob/40c9379db9ee15e712f7d0ef546b32b12e8df74b/FuelSDK/rest.py#L300-L301) which incorrectly checks the `m_filter` argument instead of `m_options`

To make this work, I instead pulled the [getMoreResults](https://github.com/salesforce-marketingcloud/FuelSDK-Python/blob/40c9379db9ee15e712f7d0ef546b32b12e8df74b/FuelSDK/rest.py#L314-L318) implementation out of the FuelSDK module and into this tap so that I could change the definition of `ET_Continue`. In the `ET_Continue` constructor, I added this line of code:
```
        ws_continueRequest.Options.BatchSize = batch_size
```

All told, this correctly sets the batch size for requests to the Salesforce Marketing Cloud / Exact Target API. I verified this with a new log line that reports the number of rows synced in each batch.

As-is, this PR won't actually fix the memory issues we're seeing in Stitch. I preserved all of the old defaults, so this tap should work 100% exactly the way it did prior to this PR. My hope is that Stitch can either expose the `batch_size` config in the UI, or set it to some lower value (like 1000, or 100) as required on their servers.

Last, I did some quick profiling to figure out what kind of impact this change had on memory usage for the tap. The default batch size (2500 rows) peaks around 1gb of memory, which I assume is the limit that Stitch has in place for taps? The lower batch sizes use considerably less memory, but will require more API calls. This is non-scientific, but it helped confirm for me that changing the batch size reduces memory usage:

<img width="1134" alt="Screen Shot 2019-08-07 at 5 49 26 PM" src="https://user-images.githubusercontent.com/1541139/62661203-5cf23980-b93e-11e9-88b3-e119b2146cac.png">

Please let me know if you have any questions - we're keen to get this tap running successfully in Stitch!