### PR TITLE
Support for OAuth2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -104,3 +104,4 @@ ENV/
 .tramp_history
 config.json
 catalog.json
+.idea/

--- a/README.md
+++ b/README.md
@@ -34,10 +34,11 @@ pip install .
 - create a Salesforce Marketing Cloud App,
 - authenticate it to your Exacttarget account, then
 - get client ID and secret. Save these -- you'll need them in the next step.
+- Find out if the sales force integration package is created (after 1st Aug, 2019) with only [OAuth2 support](https://help.salesforce.com/articleView?id=mc_rn_january_2019_platform_ip_enhanced_functionality_oauth2_0.htm&type=5)
 
 3. Create the config file.
 
-There is a template you can use at `config.json.example`, just copy it to `config.json` in the repo root and insert your client ID and secret.
+There is a template you can use at `config.json.example`, just copy it to `config.json` in the repo root and insert your client ID and secret and update use_oauth2 flag.
 
 4. Run the application to generate a catalog.
 

--- a/config.json.example
+++ b/config.json.example
@@ -1,6 +1,7 @@
 {
     "client_id": "",
     "client_secret": "",
+    "use_oauth2": "True",
     "start_date": "2014-01-01T00:00:00Z",
     "request_timeout": "900",
     "batch_size": 2500,

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         'singer-python>=5.3.1',
         'python-dateutil==2.6.0',
         'voluptuous==0.10.5',
-        'Salesforce-FuelSDK==1.1.1'
+        'Salesforce-FuelSDK==1.3.0'
     ],
     extras_require={
         'dev': [

--- a/tap_exacttarget/client.py
+++ b/tap_exacttarget/client.py
@@ -50,7 +50,7 @@ def get_auth_stub(config):
             params['authenticationurl'] = ('https://{}.auth.marketingcloudapis.com/v1/requestToken'
                                            .format(config['tenant_subdomain']))
 
-        LOGGER.info(f"Authentication URL is: {params['authenticationurl']}")
+        LOGGER.debug(f"Authentication URL is: {params['authenticationurl']}")
         params['soapendpoint'] = ('https://{}.soap.marketingcloudapis.com/Service.asmx'
                                   .format(config['tenant_subdomain']))
 

--- a/tap_exacttarget/client.py
+++ b/tap_exacttarget/client.py
@@ -40,8 +40,17 @@ def get_auth_stub(config):
 
     if config.get('tenant_subdomain'):
         # For S10+ accounts: https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/your-subdomain-tenant-specific-endpoints.htm
-        params['authenticationurl'] = ('https://{}.auth.marketingcloudapis.com/v1/requestToken'
-                                       .format(config['tenant_subdomain']))
+        # Move to OAuth2: https://help.salesforce.com/articleView?id=mc_rn_january_2019_platform_ip_remove_legacy_package_create_ability.htm&type=5
+        if config.get('use_oauth2') == "True":
+            params['useOAuth2Authentication'] = "True"
+            params['authenticationurl'] = ('https://{}.auth.marketingcloudapis.com'
+                                           .format(config['tenant_subdomain']))
+        else:
+            params['useOAuth2Authentication'] = "False"
+            params['authenticationurl'] = ('https://{}.auth.marketingcloudapis.com/v1/requestToken'
+                                           .format(config['tenant_subdomain']))
+
+        LOGGER.info(f"Authentication URL is: {params['authenticationurl']}")
         params['soapendpoint'] = ('https://{}.soap.marketingcloudapis.com/Service.asmx'
                                   .format(config['tenant_subdomain']))
 


### PR DESCRIPTION
- Updated Fuel SDK to latest which has support for OAuth2.0
- Added client configuration use_oauth2/useOAuth2Authentication to switch between legacy v1 and OAuth2 endpoints.
- Updated docs

https://help.salesforce.com/articleView?id=mc_rn_january_2019_platform_ip_remove_legacy_package_create_ability.htm&type=5