### PR TITLE
Hotfix/oauth2 support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ It:
 
 - Generates a catalog of available data in Exacttarget
 - Extracts the following resources:
-  - [Campaigns](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/campaign.htm) ([source](../blob/master/campaigns.py))
-  - [Content Areas](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/contentarea.htm) ([source](../blob/master/content_areas.py))
-  - [Data Extensions](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/dataextension.htm) and their corresponding [rows](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/dataextensionobject.htm) ([source](../blob/master/data_extensions.py))
-  - [Emails](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/email.htm) ([source](../blob/master/emails.py))
-  - Events: Each of [BounceEvent](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/bounceevent.htm), [ClickEvent](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/clickevent.htm), [OpenEvent](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/openevent.htm), [SentEvent](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/sentevent.htm), [UnsubEvent](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/unsubevent.htm) go into a single `event` table ([source](../blob/master/events.py))
-  - [Folders](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/datafolder.htm) ([source](../blob/master/folders.py))
-  - [List Subscribers](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/listsubscriber.htm) ([source](../blob/master/list_subscribers.py))
-  - [Lists](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/list.htm) ([source](../blob/master/lists.py))
-  - [Sends](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/send.htm) ([source](../blob/master/sends.py))
-  - [Subscribers](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/send.htm) (requires List Subscribers) ([source](../blob/master/subscribers.py))
+  - [Campaigns](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/campaign.htm) ([source](../master/tap_exacttarget/endpoints/campaigns.py))
+  - [Content Areas](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/contentarea.htm) ([source](../master/tap_exacttarget/endpoints/content_areas.py))
+  - [Data Extensions](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/dataextension.htm) and their corresponding [rows](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/dataextensionobject.htm) ([source](../master/tap_exacttarget/endpoints/data_extensions.py))
+  - [Emails](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/email.htm) ([source](../master/tap_exacttarget/endpoints/emails.py))
+  - Events: Each of [BounceEvent](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/bounceevent.htm), [ClickEvent](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/clickevent.htm), [OpenEvent](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/openevent.htm), [SentEvent](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/sentevent.htm), [UnsubEvent](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/unsubevent.htm) go into a single `event` table ([source](../master/tap_exacttarget/endpoints/events.py))
+  - [Folders](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/datafolder.htm) ([source](../master/tap_exacttarget/endpoints/folders.py))
+  - [List Subscribers](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/listsubscriber.htm) ([source](../master/tap_exacttarget/endpoints/list_subscribers.py))
+  - [Lists](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/list.htm) ([source](../master/tap_exacttarget/endpoints/lists.py))
+  - [Sends](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/send.htm) ([source](../master/tap_exacttarget/endpoints/sends.py))
+  - [Subscribers](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/send.htm) (requires List Subscribers) ([source](../master/tap_exacttarget/endpoints/subscribers.py))
 
 ### Quick Start
 
@@ -31,13 +31,15 @@ pip install .
 
 2. Get credentials from Exacttarget. You'll need to:
 
-- create a Salesforce Marketing Cloud App,
-- authenticate it to your Exacttarget account, then
-- get client ID and secret. Save these -- you'll need them in the next step.
+- Create a Salesforce Marketing Cloud App
+- Authenticate it to your Exacttarget account
+- Get client ID and secret. Save these -- you'll need them in the next step.
+- Find out if the sales force integration package is created (after 1st Aug, 2019) with only [OAuth2 support](https://help.salesforce.com/articleView?id=mc_rn_january_2019_platform_ip_enhanced_functionality_oauth2_0.htm&type=5)
+- Find your tenant subdomain **{tenant-subdomin}**.login.exacttarget.com
 
 3. Create the config file.
 
-There is a template you can use at `config.json.example`, just copy it to `config.json` in the repo root and insert your client ID and secret.
+There is a template you can use at `config.json.example`, just copy it to `config.json` in the repo root and insert your client_id, client_secret, tenant_subdomain and update use_oauth2 flag.
 
 4. Run the application to generate a catalog.
 

--- a/config.json.example
+++ b/config.json.example
@@ -2,6 +2,7 @@
     "client_id": "",
     "client_secret": "",
     "tenant_subdomain": "",
+    "use_oauth2": "True",
     "start_date": "2014-01-01T00:00:00Z",
     "request_timeout": "900",
     "batch_size": 2500,

--- a/config.json.example
+++ b/config.json.example
@@ -1,6 +1,7 @@
 {
     "client_id": "",
     "client_secret": "",
+    "tenant_subdomain": "",
     "start_date": "2014-01-01T00:00:00Z",
     "request_timeout": "900",
     "batch_size": 2500,

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         'singer-python>=5.3.1',
         'python-dateutil==2.6.0',
         'voluptuous==0.10.5',
-        'Salesforce-FuelSDK==1.1.1'
+        'Salesforce-FuelSDK==1.3.0'
     ],
     extras_require={
         'dev': [

--- a/tap_exacttarget/client.py
+++ b/tap_exacttarget/client.py
@@ -40,8 +40,17 @@ def get_auth_stub(config):
 
     if config.get('tenant_subdomain'):
         # For S10+ accounts: https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/your-subdomain-tenant-specific-endpoints.htm
-        params['authenticationurl'] = ('https://{}.auth.marketingcloudapis.com/v1/requestToken'
-                                       .format(config['tenant_subdomain']))
+        # Move to OAuth2: https://help.salesforce.com/articleView?id=mc_rn_january_2019_platform_ip_remove_legacy_package_create_ability.htm&type=5
+        if config.get('use_oauth2') == "True":
+            params['useOAuth2Authentication'] = "True"
+            params['authenticationurl'] = ('https://{}.auth.marketingcloudapis.com'
+                                           .format(config['tenant_subdomain']))
+        else:
+            params['useOAuth2Authentication'] = "False"
+            params['authenticationurl'] = ('https://{}.auth.marketingcloudapis.com/v1/requestToken'
+                                           .format(config['tenant_subdomain']))
+
+        LOGGER.debug(f"Authentication URL is: {params['authenticationurl']}")
         params['soapendpoint'] = ('https://{}.soap.marketingcloudapis.com/Service.asmx'
                                   .format(config['tenant_subdomain']))
 


### PR DESCRIPTION
# Description of change
- Added client configuration use_oauth2/useOAuth2Authentication to switch between legacy v1 and OAuth2 endpoints.
- Updated Fuel SDK to latest which has support for OAuth2.0
- Updated the README to reflect the new OAuth2.0 changes and fixed broken source links

# Manual QA steps
 - Create a new Salesforce Marketing Cloud App and authenticate it to your Exacttarget account
- Enter in the `client_id`, `client_secret`, `tenant_subdomain` and `"use_oauth2": "True"` into the config.json file.
- Make sure you can generate a catalog using 
```bash
tap-exacttarget -c config.json --discover > catalog.json
```
# Risks
 - Backwards compatibility with salesforce integration packages created before 1st Aug, 2019
 
# Rollback steps
 - revert this branch
