### PR TITLE
Add OAuth2 Support

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,16 +8,16 @@ It:
 
 - Generates a catalog of available data in Exacttarget
 - Extracts the following resources:
-  - [Campaigns](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/campaign.htm) ([source](../blob/master/campaigns.py))
-  - [Content Areas](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/contentarea.htm) ([source](../blob/master/content_areas.py))
-  - [Data Extensions](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/dataextension.htm) and their corresponding [rows](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/dataextensionobject.htm) ([source](../blob/master/data_extensions.py))
-  - [Emails](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/email.htm) ([source](../blob/master/emails.py))
-  - Events: Each of [BounceEvent](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/bounceevent.htm), [ClickEvent](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/clickevent.htm), [OpenEvent](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/openevent.htm), [SentEvent](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/sentevent.htm), [UnsubEvent](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/unsubevent.htm) go into a single `event` table ([source](../blob/master/events.py))
-  - [Folders](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/datafolder.htm) ([source](../blob/master/folders.py))
-  - [List Subscribers](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/listsubscriber.htm) ([source](../blob/master/list_subscribers.py))
-  - [Lists](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/list.htm) ([source](../blob/master/lists.py))
-  - [Sends](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/send.htm) ([source](../blob/master/sends.py))
-  - [Subscribers](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/send.htm) (requires List Subscribers) ([source](../blob/master/subscribers.py))
+  - [Campaigns](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/campaign.htm) ([source](../master/tap_exacttarget/endpoints/campaigns.py))
+  - [Content Areas](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/contentarea.htm) ([source](../master/tap_exacttarget/endpoints/content_areas.py))
+  - [Data Extensions](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/dataextension.htm) and their corresponding [rows](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/dataextensionobject.htm) ([source](../master/tap_exacttarget/endpoints/data_extensions.py))
+  - [Emails](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/email.htm) ([source](../master/tap_exacttarget/endpoints/emails.py))
+  - Events: Each of [BounceEvent](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/bounceevent.htm), [ClickEvent](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/clickevent.htm), [OpenEvent](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/openevent.htm), [SentEvent](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/sentevent.htm), [UnsubEvent](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/unsubevent.htm) go into a single `event` table ([source](../master/tap_exacttarget/endpoints/events.py))
+  - [Folders](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/datafolder.htm) ([source](../master/tap_exacttarget/endpoints/folders.py))
+  - [List Subscribers](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/listsubscriber.htm) ([source](../master/tap_exacttarget/endpoints/list_subscribers.py))
+  - [Lists](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/list.htm) ([source](../master/tap_exacttarget/endpoints/lists.py))
+  - [Sends](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/send.htm) ([source](../master/tap_exacttarget/endpoints/sends.py))
+  - [Subscribers](https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/send.htm) (requires List Subscribers) ([source](../master/tap_exacttarget/endpoints/subscribers.py))
 
 ### Quick Start
 
@@ -31,13 +31,15 @@ pip install .
 
 2. Get credentials from Exacttarget. You'll need to:
 
-- create a Salesforce Marketing Cloud App,
-- authenticate it to your Exacttarget account, then
-- get client ID and secret. Save these -- you'll need them in the next step.
+- Create a Salesforce Marketing Cloud App
+- Authenticate it to your Exacttarget account
+- Get client ID and secret. Save these -- you'll need them in the next step.
+- Find out if the sales force integration package is created (after 1st Aug, 2019) with only [OAuth2 support](https://help.salesforce.com/articleView?id=mc_rn_january_2019_platform_ip_enhanced_functionality_oauth2_0.htm&type=5)
+- Find your tenant subdomain **{tenant-subdomin}**.login.exacttarget.com
 
 3. Create the config file.
 
-There is a template you can use at `config.json.example`, just copy it to `config.json` in the repo root and insert your client ID and secret.
+There is a template you can use at `config.json.example`, just copy it to `config.json` in the repo root and insert your client_id, client_secret, tenant_subdomain and update use_oauth2 flag.
 
 4. Run the application to generate a catalog.
 

--- a/README.md
+++ b/README.md
@@ -36,10 +36,11 @@ pip install .
 - Get client ID and secret. Save these -- you'll need them in the next step.
 - Find out if the sales force integration package is created (after 1st Aug, 2019) with only [OAuth2 support](https://help.salesforce.com/articleView?id=mc_rn_january_2019_platform_ip_enhanced_functionality_oauth2_0.htm&type=5)
 - Find your tenant subdomain **{tenant-subdomin}**.login.exacttarget.com
+- Obtian a refresh token following the steps [here](https://developer.salesforce.com/docs/atlas.en-us.mc-app-development.meta/mc-app-development/access-token-app.htm)
 
 3. Create the config file.
 
-There is a template you can use at `config.json.example`, just copy it to `config.json` in the repo root and insert your client_id, client_secret, tenant_subdomain and update use_oauth2 flag.
+There is a template you can use at `config.json.example`, just copy it to `config.json` in the repo root and insert your client_id, client_secret, tenant_subdomain and refresh_token.
 
 4. Run the application to generate a catalog.
 
@@ -63,6 +64,6 @@ tap-exacttarget -c config.json --properties catalog.json
 
 ---
 
-Embedded FuelSDK Copyright &copy; 2017 Salesforce and Licensed under the MIT License
+Embedded FuelSDK Copyright &copy; 2019 Salesforce and Licensed under the MIT License
 
-Copyright &copy; 2017 Stitch
+Copyright &copy; 2019 Stitch

--- a/config.json.example
+++ b/config.json.example
@@ -2,7 +2,7 @@
     "client_id": "",
     "client_secret": "",
     "tenant_subdomain": "",
-    "use_oauth2": "True",
+    "refresh_token": "",
     "start_date": "2014-01-01T00:00:00Z",
     "request_timeout": "900",
     "batch_size": 2500,

--- a/config.json.example
+++ b/config.json.example
@@ -2,6 +2,7 @@
     "client_id": "",
     "client_secret": "",
     "tenant_subdomain": "",
+    "use_oauth2": "True",
     "start_date": "2014-01-01T00:00:00Z",
     "request_timeout": "900",
     "batch_size": 2500,

--- a/config.json.example
+++ b/config.json.example
@@ -1,6 +1,7 @@
 {
     "client_id": "",
     "client_secret": "",
+    "tenant_subdomain": "",
     "start_date": "2014-01-01T00:00:00Z",
     "request_timeout": "900",
     "batch_size": 2500,

--- a/setup.py
+++ b/setup.py
@@ -12,7 +12,7 @@ setup(
     py_modules=['tap_exacttarget'],
     install_requires=[
         'funcy==1.9.1',
-        'singer-python>=5.3.1',
+        'singer-python==5.9.0',
         'python-dateutil==2.6.0',
         'voluptuous==0.10.5',
         'Salesforce-FuelSDK==1.3.0'

--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ setup(
         'singer-python>=5.3.1',
         'python-dateutil==2.6.0',
         'voluptuous==0.10.5',
-        'Salesforce-FuelSDK==1.1.1'
+        'Salesforce-FuelSDK==1.3.0'
     ],
     extras_require={
         'dev': [

--- a/tap_exacttarget/__init__.py
+++ b/tap_exacttarget/__init__.py
@@ -57,7 +57,7 @@ def do_discover(args):
     config = args.config
     state = args.state
 
-    auth_stub = get_auth_stub(config)
+    auth_stub = get_auth_stub(config, args.config_path)
 
     catalog = []
 
@@ -86,7 +86,7 @@ def do_sync(args):
 
     success = True
 
-    auth_stub = get_auth_stub(config)
+    auth_stub = get_auth_stub(config, args.config_path)
 
     stream_accessors = []
 

--- a/tap_exacttarget/client.py
+++ b/tap_exacttarget/client.py
@@ -8,7 +8,7 @@ from tap_exacttarget.fuel_overrides import tap_exacttarget__getMoreResults
 LOGGER = singer.get_logger()
 
 # Defined our own class whose parent is FuelSDK.ET_Client. We found that
-# the logic within FuelSDK.ET_Client.refresh_toke() wouldn't allow the refresh_token
+# the logic within FuelSDK.ET_Client.refresh_token() wouldn't allow the refresh_token
 # to be used correctly so we need to manually set self.refreshKey.
 class SFMCClient(FuelSDK.ET_Client):
     #pylint: disable=super-init-not-called

--- a/tap_exacttarget/client.py
+++ b/tap_exacttarget/client.py
@@ -40,8 +40,17 @@ def get_auth_stub(config):
 
     if config.get('tenant_subdomain'):
         # For S10+ accounts: https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/your-subdomain-tenant-specific-endpoints.htm
-        params['authenticationurl'] = ('https://{}.auth.marketingcloudapis.com/v1/requestToken'
-                                       .format(config['tenant_subdomain']))
+        # Move to OAuth2: https://help.salesforce.com/articleView?id=mc_rn_january_2019_platform_ip_remove_legacy_package_create_ability.htm&type=5
+        if config.get('use_oauth2') == "True":
+            params['useOAuth2Authentication'] = "True"
+            params['authenticationurl'] = ('https://{}.auth.marketingcloudapis.com'
+                                           .format(config['tenant_subdomain']))
+        else:
+            params['useOAuth2Authentication'] = "False"
+            params['authenticationurl'] = ('https://{}.auth.marketingcloudapis.com/v1/requestToken'
+                                           .format(config['tenant_subdomain']))
+
+        LOGGER.debug(f"Authentication URL is: {params['authenticationurl']}")
         params['soapendpoint'] = ('https://{}.soap.marketingcloudapis.com/Service.asmx'
                                   .format(config['tenant_subdomain']))
 

--- a/tap_exacttarget/client.py
+++ b/tap_exacttarget/client.py
@@ -1,11 +1,59 @@
 import FuelSDK
 import singer
+import json
 
 from suds.transport.https import HttpAuthenticated
 from tap_exacttarget.fuel_overrides import tap_exacttarget__getMoreResults
 
 LOGGER = singer.get_logger()
 
+# Defined our own class whose parent is FuelSDK.ET_Client. We found that
+# the logic within FuelSDK.ET_Client.refresh_toke() wouldn't allow the refresh_token
+# to be used correctly so we need to manually set self.refreshKey.
+class SFMCClient(FuelSDK.ET_Client):
+    def __init__(self, config, config_path):
+        if config.get('refresh_token'):
+            self.refreshKey = config['refresh_token']
+
+        self.config_path = config_path
+        self.config = config
+
+        params = {
+            'clientid': config['client_id'],
+            'clientsecret': config['client_secret']
+        }
+
+        if config.get('tenant_subdomain'):
+            # For S10+ accounts: https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/your-subdomain-tenant-specific-endpoints.htm
+            # Move to OAuth2: https://help.salesforce.com/articleView?id=mc_rn_january_2019_platform_ip_remove_legacy_package_create_ability.htm&type=5
+            if config.get('refresh_token'):
+                params['useOAuth2Authentication'] = "True"
+                params['authenticationurl'] = ('https://{}.auth.marketingcloudapis.com'
+                                               .format(config['tenant_subdomain']))
+            else:
+                params['useOAuth2Authentication'] = "False"
+                params['authenticationurl'] = ('https://{}.auth.marketingcloudapis.com/v1/requestToken'
+                                               .format(config['tenant_subdomain']))
+
+
+            LOGGER.debug("Authentication URL is: {}".format(params['authenticationurl']))
+            params['soapendpoint'] = ('https://{}.soap.marketingcloudapis.com/Service.asmx'
+                                      .format(config['tenant_subdomain']))
+
+        # Call configure_client from the parent class
+        self.configure_client(False, params, None)
+
+
+    # Define our own refresh_token to capture when refresh_token is updated and write it back
+    # to the config file.
+    def refresh_token(self, force_refresh=False):
+        super().refresh_token()
+
+        if 'refresh_token' in self.config and self.config.get('refresh_token') != self.refreshKey:
+            LOGGER.info("Refresh Token changed during  refresh_token")
+            self.config['refresh_token'] = self.refreshKey
+            with open(self.config_path, 'w') as file:
+                json.dump(self.config, file, indent=2)
 
 def _get_response_items(response):
     items = response.results
@@ -22,7 +70,7 @@ __all__ = ['get_auth_stub', 'request', 'request_from_cursor']
 
 # PUBLIC FUNCTIONS
 
-def get_auth_stub(config):
+def get_auth_stub(config, config_path):
     """
     Given a config dict in the format:
 
@@ -33,28 +81,9 @@ def get_auth_stub(config):
     """
     LOGGER.info("Generating auth stub...")
 
-    params = {
-        'clientid': config['client_id'],
-        'clientsecret': config['client_secret']
-        }
+    # Create our SFMC Client which adds functionality to the library's version
+    auth_stub = SFMCClient(config, config_path)
 
-    if config.get('tenant_subdomain'):
-        # For S10+ accounts: https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/your-subdomain-tenant-specific-endpoints.htm
-        # Move to OAuth2: https://help.salesforce.com/articleView?id=mc_rn_january_2019_platform_ip_remove_legacy_package_create_ability.htm&type=5
-        if config.get('use_oauth2') == "True":
-            params['useOAuth2Authentication'] = "True"
-            params['authenticationurl'] = ('https://{}.auth.marketingcloudapis.com'
-                                           .format(config['tenant_subdomain']))
-        else:
-            params['useOAuth2Authentication'] = "False"
-            params['authenticationurl'] = ('https://{}.auth.marketingcloudapis.com/v1/requestToken'
-                                           .format(config['tenant_subdomain']))
-
-        LOGGER.debug(f"Authentication URL is: {params['authenticationurl']}")
-        params['soapendpoint'] = ('https://{}.soap.marketingcloudapis.com/Service.asmx'
-                                  .format(config['tenant_subdomain']))
-
-    auth_stub = FuelSDK.ET_Client(params=params)
     transport = HttpAuthenticated(timeout=int(config.get('request_timeout', 900)))
     auth_stub.soap_client.set_options(
         transport=transport)

--- a/tap_exacttarget/client.py
+++ b/tap_exacttarget/client.py
@@ -11,6 +11,7 @@ LOGGER = singer.get_logger()
 # the logic within FuelSDK.ET_Client.refresh_toke() wouldn't allow the refresh_token
 # to be used correctly so we need to manually set self.refreshKey.
 class SFMCClient(FuelSDK.ET_Client):
+    #pylint: disable=super-init-not-called
     def __init__(self, config, config_path):
         if config.get('refresh_token'):
             self.refreshKey = config['refresh_token']


### PR DESCRIPTION
# Description of change
The SFMC recently deprecated basic auth in favor of OAuth2. This change adds support for OAuth2 to the tap by allowing users to pass a `refresh_token` parameter in the config file.  

# Manual QA steps
 -  Cloned connection with legacy auth properties and verified that this did not break functionality
 - Created connection with our test credentials and verified that we can use oauth2 to get refresh token and run tap with it.
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
