### PR TITLE
try v1 endpoint and fall back to v2

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -16,7 +16,7 @@ jobs:
           name: 'unittest'
           command: |
             source /usr/local/share/virtualenvs/tap-exacttarget/bin/activate
-            python3 -m unittest
+            nosetests tests/unittests
       - run:
           name: 'pylint'
           command: |
@@ -29,13 +29,13 @@ jobs:
             aws s3 cp s3://com-stitchdata-dev-deployment-assets/environments/tap-tester/sandbox dev_env.sh
             source dev_env.sh
             source /usr/local/share/virtualenvs/tap-tester/bin/activate
-            run-a-test --tap=tap-exacttarget \
+            run-test --tap=tap-exacttarget \
                        --target=target-stitch \
                        --orchestrator=stitch-orchestrator \
                        --email=harrison+sandboxtest@stitchdata.com \
                        --password=$SANDBOX_PASSWORD \
                        --client-id=50 \
-                       tap_tester.suites.exacttarget
+                       tests
 workflows:
   version: 2
   commit:

--- a/config.json.example
+++ b/config.json.example
@@ -2,7 +2,6 @@
     "client_id": "",
     "client_secret": "",
     "tenant_subdomain": "",
-    "refresh_token": "",
     "start_date": "2014-01-01T00:00:00Z",
     "request_timeout": "900",
     "batch_size": 2500,

--- a/setup.py
+++ b/setup.py
@@ -22,6 +22,7 @@ setup(
             'ipdb==0.11',
             'pylint==2.1.1',
             'astroid==2.1.0',
+            'nose'
         ]
     },
     entry_points='''

--- a/tap_exacttarget/__init__.py
+++ b/tap_exacttarget/__init__.py
@@ -57,7 +57,7 @@ def do_discover(args):
     config = args.config
     state = args.state
 
-    auth_stub = get_auth_stub(config, args.config_path)
+    auth_stub = get_auth_stub(config)
 
     catalog = []
 
@@ -86,7 +86,7 @@ def do_sync(args):
 
     success = True
 
-    auth_stub = get_auth_stub(config, args.config_path)
+    auth_stub = get_auth_stub(config)
 
     stream_accessors = []
 

--- a/tap_exacttarget/client.py
+++ b/tap_exacttarget/client.py
@@ -60,6 +60,7 @@ def get_auth_stub(config):
     except Exception as e:
         LOGGER.info('Failed to auth using V1 endpoint')
         if not config.get('tenant_subdomain'):
+            LOGGER.warning('No tenant_subdomain found, will not attempt to auth with V2 endpoint')
             raise e
 
     # Next try V2

--- a/tap_exacttarget/client.py
+++ b/tap_exacttarget/client.py
@@ -1,60 +1,11 @@
 import FuelSDK
 import singer
-import json
 
 from suds.transport.https import HttpAuthenticated
 from tap_exacttarget.fuel_overrides import tap_exacttarget__getMoreResults
 
 LOGGER = singer.get_logger()
 
-# Defined our own class whose parent is FuelSDK.ET_Client. We found that
-# the logic within FuelSDK.ET_Client.refresh_token() wouldn't allow the refresh_token
-# to be used correctly so we need to manually set self.refreshKey.
-class SFMCClient(FuelSDK.ET_Client):
-    #pylint: disable=super-init-not-called
-    def __init__(self, config, config_path):
-        if config.get('refresh_token'):
-            self.refreshKey = config['refresh_token']
-
-        self.config_path = config_path
-        self.config = config
-
-        params = {
-            'clientid': config['client_id'],
-            'clientsecret': config['client_secret']
-        }
-
-        if config.get('tenant_subdomain'):
-            # For S10+ accounts: https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/your-subdomain-tenant-specific-endpoints.htm
-            # Move to OAuth2: https://help.salesforce.com/articleView?id=mc_rn_january_2019_platform_ip_remove_legacy_package_create_ability.htm&type=5
-            if config.get('refresh_token'):
-                params['useOAuth2Authentication'] = "True"
-                params['authenticationurl'] = ('https://{}.auth.marketingcloudapis.com'
-                                               .format(config['tenant_subdomain']))
-            else:
-                params['useOAuth2Authentication'] = "False"
-                params['authenticationurl'] = ('https://{}.auth.marketingcloudapis.com/v1/requestToken'
-                                               .format(config['tenant_subdomain']))
-
-
-            LOGGER.debug("Authentication URL is: {}".format(params['authenticationurl']))
-            params['soapendpoint'] = ('https://{}.soap.marketingcloudapis.com/Service.asmx'
-                                      .format(config['tenant_subdomain']))
-
-        # Call configure_client from the parent class
-        self.configure_client(False, params, None)
-
-
-    # Define our own refresh_token to capture when refresh_token is updated and write it back
-    # to the config file.
-    def refresh_token(self, force_refresh=False):
-        super().refresh_token()
-
-        if 'refresh_token' in self.config and self.config.get('refresh_token') != self.refreshKey:
-            LOGGER.info("Refresh Token changed during  refresh_token")
-            self.config['refresh_token'] = self.refreshKey
-            with open(self.config_path, 'w') as file:
-                json.dump(self.config, file, indent=2)
 
 def _get_response_items(response):
     items = response.results
@@ -71,7 +22,7 @@ __all__ = ['get_auth_stub', 'request', 'request_from_cursor']
 
 # PUBLIC FUNCTIONS
 
-def get_auth_stub(config, config_path):
+def get_auth_stub(config):
     """
     Given a config dict in the format:
 
@@ -82,15 +33,52 @@ def get_auth_stub(config, config_path):
     """
     LOGGER.info("Generating auth stub...")
 
-    # Create our SFMC Client which adds functionality to the library's version
-    auth_stub = SFMCClient(config, config_path)
+    params = {
+        'clientid': config['client_id'],
+        'clientsecret': config['client_secret']
+        }
 
-    transport = HttpAuthenticated(timeout=int(config.get('request_timeout', 900)))
-    auth_stub.soap_client.set_options(
-        transport=transport)
+    if config.get('tenant_subdomain'):
+        # For S10+ accounts: https://developer.salesforce.com/docs/atlas.en-us.noversion.mc-apis.meta/mc-apis/your-subdomain-tenant-specific-endpoints.htm
+
+        params['authenticationurl'] = ('https://{}.auth.marketingcloudapis.com/v1/requestToken'
+                                       .format(config['tenant_subdomain']))
+        LOGGER.info("Authentication URL is: %s", params['authenticationurl'])
+        params['soapendpoint'] = ('https://{}.soap.marketingcloudapis.com/Service.asmx'
+                                  .format(config['tenant_subdomain']))
+
+    # First try V1
+    try:
+        LOGGER.info('Trying to authenticate using V1 endpoint')
+        params['useOAuth2Authentication'] = "False"
+        auth_stub = FuelSDK.ET_Client(params=params)
+        transport = HttpAuthenticated(timeout=int(config.get('request_timeout', 900)))
+        auth_stub.soap_client.set_options(
+            transport=transport)
+        LOGGER.info("Success.")
+        return auth_stub
+    except Exception as e:
+        LOGGER.info('Failed to auth using V1 endpoint')
+        if not config.get('tenant_subdomain'):
+            raise e
+
+    # Next try V2
+    # Move to OAuth2: https://help.salesforce.com/articleView?id=mc_rn_january_2019_platform_ip_remove_legacy_package_create_ability.htm&type=5
+    try:
+        LOGGER.info('Trying to authenticate using V2 endpoint')
+        params['useOAuth2Authentication'] = "True"
+        params['authenticationurl'] = ('https://{}.auth.marketingcloudapis.com'
+                                       .format(config['tenant_subdomain']))
+        LOGGER.info("Authentication URL is: %s", params['authenticationurl'])
+        auth_stub = FuelSDK.ET_Client(params=params)
+        transport = HttpAuthenticated(timeout=int(config.get('request_timeout', 900)))
+        auth_stub.soap_client.set_options(
+            transport=transport)
+    except Exception as e:
+        LOGGER.info('Failed to auth using V2 endpoint')
+        raise e
 
     LOGGER.info("Success.")
-
     return auth_stub
 
 

--- a/tests/test_exacttarget_base.py
+++ b/tests/test_exacttarget_base.py
@@ -1,0 +1,95 @@
+from tap_tester.scenario import SCENARIOS
+
+import datetime
+import tap_tester.connections as connections
+import tap_tester.menagerie as menagerie
+import tap_tester.runner as runner
+import os
+import unittest
+import pdb
+import json
+import requests
+
+
+class ExactTargetBase(unittest.TestCase):
+
+    def name(self):
+        return "tap_tester_exacttarget_base"
+
+    def tap_name(self):
+        return "tap-exacttarget"
+
+    def setUp(self):
+        required_env = {
+            "client_id": "TAP_EXACTTARGET_CLIENT_ID",
+            "client_secret": "TAP_EXACTTARGET_CLIENT_SECRET",
+        }
+        missing_envs = [v for v in required_env.values() if not os.getenv(v)]
+        if missing_envs:
+            raise Exception("set " + ", ".join(missing_envs))
+
+    def get_type(self):
+        return "platform.exacttarget"
+
+    def get_credentials(self):
+        return {
+            'client_secret': os.getenv('TAP_EXACTTARGET_CLIENT_SECRET')
+        }
+
+    def get_properties(self):
+        yesterday = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=1)
+        return {
+            'start_date': yesterday.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            'client_id': os.getenv('TAP_EXACTTARGET_CLIENT_ID')
+        }
+
+    def streams_to_select(self):
+        # Note: Custom streams failed on our account with an error on
+        # `_CustomObjectKey` not being valid
+        return ["campaign",
+                "content_area",
+                "email",
+                "event",
+                "folder",
+                "list",
+                "list_send",
+                "list_subscriber",
+                "send",
+                "subscriber"]
+
+    def select_found_catalogs(self, conn_id, found_catalogs, only_streams=None):
+        selected = []
+        for catalog in found_catalogs:
+            if only_streams and catalog["tap_stream_id"] not in only_streams:
+                continue
+            schema = menagerie.select_catalog(conn_id, catalog)
+
+            selected.append({
+                "key_properties": catalog.get("key_properties"),
+                "schema": schema,
+                "tap_stream_id": catalog.get("tap_stream_id"),
+                "replication_method": catalog.get("replication_method"),
+                "replication_key": catalog.get("replication_key"),
+            })
+
+        for catalog_entry in selected:
+            connections.select_catalog_and_fields_via_metadata(
+                conn_id,
+                catalog_entry,
+                {"annotated-schema": catalog_entry['schema']}
+            )
+
+    def test_run(self):
+        conn_id = connections.ensure_connection(self)
+        runner.run_check_mode(self, conn_id)
+
+        found_catalogs = menagerie.get_catalogs(conn_id)
+        self.select_found_catalogs(conn_id, found_catalogs, only_streams=self.streams_to_select())
+        sync_job_name = runner.run_sync_mode(self, conn_id)
+
+        # verify tap and target exit codes
+        exit_status = menagerie.get_exit_status(conn_id, sync_job_name)
+        menagerie.verify_sync_exit_status(self, exit_status, sync_job_name)
+
+
+SCENARIOS.add(ExactTargetBase)

--- a/tests/test_exacttarget_discover.py
+++ b/tests/test_exacttarget_discover.py
@@ -1,0 +1,101 @@
+import datetime
+import tap_tester.connections as connections
+import tap_tester.menagerie as menagerie
+import tap_tester.runner as runner
+import os
+import unittest
+import pdb
+import json
+import requests
+
+
+class ExactTargetDiscover(unittest.TestCase):
+
+    def name(self):
+        return "tap_tester_exacttarget_discover_v1"
+
+    def tap_name(self):
+        return "tap-exacttarget"
+
+    def setUp(self):
+        required_env = {
+            "TAP_EXACTTARGET_CLIENT_ID",
+            "TAP_EXACTTARGET_CLIENT_SECRET",
+            "TAP_EXACTTARGET_TENANT_SUBDOMAIN",
+            "TAP_EXACTTARGET_V2_CLIENT_ID",
+            "TAP_EXACTTARGET_V2_CLIENT_SECRET",
+            "TAP_EXACTTARGET_V2_TENANT_SUBDOMAIN",
+        }
+        missing_envs = [v for v in required_env if not os.getenv(v)]
+        if missing_envs:
+            raise Exception("set " + ", ".join(missing_envs))
+
+    def get_type(self):
+        return "platform.exacttarget"
+
+    def get_credentials(self):
+        return {
+            'client_secret': os.getenv('TAP_EXACTTARGET_CLIENT_SECRET')
+        }
+
+    def get_properties(self):
+        yesterday = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=1)
+        return {
+            'start_date': yesterday.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            'client_id': os.getenv('TAP_EXACTTARGET_CLIENT_ID')
+        }
+
+    def test_run(self):
+        conn_id = connections.ensure_connection(self)
+        runner.run_check_mode(self, conn_id)
+
+        found_catalog = menagerie.get_catalog(conn_id)
+        for catalog_entry in found_catalog['streams']:
+            field_names_in_schema = set([ k for k in catalog_entry['schema']['properties'].keys()])
+            field_names_in_breadcrumbs = set([x['breadcrumb'][1] for x in catalog_entry['metadata'] if len(x['breadcrumb']) == 2])
+            self.assertEqual(field_names_in_schema, field_names_in_breadcrumbs)
+
+            inclusions_set = set([(x['breadcrumb'][1], x['metadata']['inclusion'])
+                                  for x in catalog_entry['metadata']
+                                  if len(x['breadcrumb']) == 2])
+            # Validate that all fields are in metadata
+            self.assertEqual(len(inclusions_set), len(field_names_in_schema))
+            self.assertEqual(set([i[0] for i in inclusions_set]), field_names_in_schema)
+            # Validate that all metadata['inclusion'] are 'available'
+            unique_inclusions = set([i[1] for i in inclusions_set])
+            self.assertTrue(len(unique_inclusions) == 1 and 'available' in unique_inclusions)
+
+class ExactTargetDiscover2(ExactTargetDiscover):
+    def name(self):
+        return "tap_tester_exacttarget_discover_v1_with_subdomain"
+
+    def get_credentials(self):
+        return {
+            'client_secret': os.getenv('TAP_EXACTTARGET_CLIENT_SECRET')
+        }
+
+    def get_properties(self):
+        yesterday = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=1)
+        return {
+            'start_date': yesterday.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            'client_id': os.getenv('TAP_EXACTTARGET_CLIENT_ID'),
+            'tenant_subdomain': os.getenv('TAP_EXACTTARGET_TENANT_SUBDOMAIN')
+        }
+
+
+class ExactTargetDiscover3(ExactTargetDiscover):
+    def name(self):
+        return "tap_tester_exacttarget_discover_v2_with_subdomain"
+
+    def get_credentials(self):
+        return {
+            'client_secret': os.getenv('TAP_EXACTTARGET_V2_CLIENT_SECRET')
+        }
+
+    def get_properties(self):
+        yesterday = datetime.datetime.now(datetime.timezone.utc) - datetime.timedelta(days=1)
+        return {
+            'start_date': yesterday.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            'client_id': os.getenv('TAP_EXACTTARGET_V2_CLIENT_ID'),
+            'tenant_subdomain': os.getenv('TAP_EXACTTARGET_V2_TENANT_SUBDOMAIN')
+        }

--- a/tests/unittests/test_pagination.py
+++ b/tests/unittests/test_pagination.py
@@ -1,5 +1,5 @@
 import unittest
-
+import tap_exacttarget
 from tap_exacttarget.pagination import increment_date
 
 

--- a/tests/unittests/test_state.py
+++ b/tests/unittests/test_state.py
@@ -1,5 +1,5 @@
 import unittest
-
+import tap_exacttarget
 from tap_exacttarget.state import incorporate
 
 

--- a/tests/unittests/test_util.py
+++ b/tests/unittests/test_util.py
@@ -1,5 +1,5 @@
 import unittest
-
+import tap_exacttarget
 from tap_exacttarget.util import partition_all
 
 


### PR DESCRIPTION
# Description of change
This change reintroduces support for OAuth2, but instead of supporting web apps, the tap will be supporting server-to-server integrations.

Support for legacy integrations will remain, both those with a `tenant_subdomain` and those without one.

The tap will first try to hit the V1 auth endpoint, and if it fails (and has a `tenant_subdomain`), will try to hit the V2 auth endpoint.  

# Manual QA steps
Tried on 3 types of cloned connections:
  - Legacy V1 without `tenant_subdomain`
  - Legacy V1 with `tenant_subdomain`
  - New V2 with `tenant_subdomain`

and verified that all 3 can auth succesfully
 
# Risks
 - None
 
# Rollback steps
 - revert this branch
