### PR TITLE
bump version to 1.6.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,8 @@
 # Changelog
 
+## 1.6.1
+  * Add OAuth2 support but using server-to-server integrations [#47](https://github.com/singer-io/tap-exacttarget/pull/47)
+
 ## 1.6.0
   * Add OAuth2 support [#43](https://github.com/singer-io/tap-exacttarget/pull/43)
 

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='tap-exacttarget',
-    version='1.6.0',
+    version='1.6.1',
     description='Singer.io tap for extracting data from the ExactTarget API',
     author='Fishtown Analytics',
     url='http://fishtownanalytics.com',


### PR DESCRIPTION
# Description of change
bump version to 1.6.1

# Manual QA steps
 - None
 
# Risks
 - None
 
# Rollback steps
 - revert this branch
