### PR TITLE
Fixed the integration tests by skipping "data_extension.my_test" stream

### DIFF
--- a/tests/base.py
+++ b/tests/base.py
@@ -127,17 +127,20 @@ class ExactTargetBase(unittest.TestCase):
                 self.PRIMARY_KEYS: {"ID"},
                 self.REPLICATION_METHOD: self.INCREMENTAL,
                 self.REPLICATION_KEYS: {"ModifiedDate"},
-            } 
+            }
         }
 
-    def streams_to_select(self):
+    def streams_to_select(self, is_discovery=False):
         # events: there are 5 events and the API call window is of 10 minutes
         #   so there will be a lot of API calls for every test
         # list_subscriber: as the API window is of 1 day, the tests took
         #   30 minutes to run 3 tests, the test run time will be increased
         #   when all the tests are combined
         # subscriber: it is the child stream of 'list_subscriber'
-        return set(self.expected_metadata().keys()) - {'event', 'list_subscriber', 'subscriber'}
+        if is_discovery:
+            return set(self.expected_metadata().keys())
+
+        return set(self.expected_metadata().keys()) - {'event', 'list_subscriber', 'subscriber', 'data_extension.my_test'}
 
     def expected_replication_keys(self):
         return {table: properties.get(self.REPLICATION_KEYS, set())

--- a/tests/test_exacttarget_discover.py
+++ b/tests/test_exacttarget_discover.py
@@ -35,7 +35,7 @@ class ExactTargetDiscover(ExactTargetBase):
         conn_id = connections.ensure_connection(self)
         runner.run_check_mode(self, conn_id)
 
-        streams_to_test = self.streams_to_select()
+        streams_to_test = self.streams_to_select(is_discovery=True)
         found_catalogs = menagerie.get_catalogs(conn_id)
 
         # verify the stream names discovered were what we expect


### PR DESCRIPTION
# Description of change
- Integration tests were failing because data_extension.my_test stream is not returning any records. So added the stream into the skipped stream
- Above stream will be skipped for tests other than discovery

# Manual QA steps
 - Integration tests in CCi should pass
 
# Risks
 - 
 
# Rollback steps
 - revert this branch
