### PR TITLE
Update replication key mapping and add null filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,11 @@
 # Changelog
 
+## 2.2.0
+ * Support for EventDate/Time replication keys and support for null filter [#109](https://github.com/singer-io/tap-exacttarget/pull/109)
+
+
 ## 2.1.0
  * Schema and tap improvement [#104](https://github.com/singer-io/tap-exacttarget/pull/104)
-
-
 
 ## 2.0.0
  * Replace fuelsdk and rewrite tap using zeep [#100](https://github.com/singer-io/tap-exacttarget/pull/100)

--- a/setup.py
+++ b/setup.py
@@ -4,7 +4,7 @@ from setuptools import find_packages, setup
 
 setup(
     name="tap-exacttarget",
-    version="2.1.0",
+    version="2.2.0",
     description="Singer.io tap for extracting data from the ExactTarget API",
     author="Singer.io",
     url="https://singer.io",

--- a/tap_exacttarget/discover_dataextensionobj.py
+++ b/tap_exacttarget/discover_dataextensionobj.py
@@ -15,8 +15,8 @@ field_type_mapping = {
     "Text": "string",
     "Date": "string",
 }
-supported_repl_keys = ["ModifiedDate", "JoinDate", "_ModifiedDate", "_CreatedDate", "EventDatetime", "EventDate"]
-priority_event_repl_keys = ["EventDatetime", "EventDate"]
+supported_repl_keys = ["ModifiedDate", "JoinDate", "_ModifiedDate", "_CreatedDate", "EventDateTime", "EventDate"]
+priority_event_repl_keys = ["EventDateTime", "EventDate"]
 
 field_format = {"Decimal": "singer.decimal", "Date": "date-time"}
 

--- a/tap_exacttarget/discover_dataextensionobj.py
+++ b/tap_exacttarget/discover_dataextensionobj.py
@@ -15,9 +15,29 @@ field_type_mapping = {
     "Text": "string",
     "Date": "string",
 }
-supported_repl_keys = ["ModifiedDate", "JoinDate", "_ModifiedDate", "_CreatedDate"]
+supported_repl_keys = ["ModifiedDate", "JoinDate", "_ModifiedDate", "_CreatedDate", "EventDatetime", "EventDate"]
+priority_event_repl_keys = ["EventDatetime", "EventDate"]
 
 field_format = {"Decimal": "singer.decimal", "Date": "date-time"}
+
+
+def select_replication_key(repl_keys):
+    """
+    If a data_extension table has EventDatetime or EventDate
+    it is likely to be a table populated via a event
+    such tables should use EventDatetime or EventDate over
+    the regular replication keys they do not contain value for modified_at field
+    because these events are immutable in nature.
+    """
+    for event_key in priority_event_repl_keys:
+        if event_key in repl_keys:
+            return event_key
+
+    for key in supported_repl_keys:
+        if key in repl_keys:
+            return key
+
+    return next(iter(repl_keys), None)
 
 
 def detect_field_schema(field):
@@ -112,14 +132,7 @@ def discover_dao_streams(client: Client):
                 },
             }
 
-            # Modified Date is the preferred replication key
-            # Maintaining original sequence of the key picking order
-            replication_key = next(
-                (
-                    key for key in supported_repl_keys if key in repl_keys
-                ),
-                None,
-            )
+            replication_key = select_replication_key(repl_keys)
 
             #  Sanitize the stream name to create a valid Python class name by removing special characters.
             name_suffix = stream_name.strip().lower()

--- a/tap_exacttarget/discover_dataextensionobj.py
+++ b/tap_exacttarget/discover_dataextensionobj.py
@@ -15,8 +15,8 @@ field_type_mapping = {
     "Text": "string",
     "Date": "string",
 }
-supported_repl_keys = ["ModifiedDate", "JoinDate", "_ModifiedDate", "_CreatedDate", "EventDateTime", "EventDate"]
-priority_event_repl_keys = ["EventDateTime", "EventDate"]
+supported_repl_keys = ["ModifiedDate", "JoinDate", "_ModifiedDate", "_CreatedDate", "EventDatetime", "EventDate"]
+priority_event_repl_keys = ["EventDatetime", "EventDate"]
 
 field_format = {"Decimal": "singer.decimal", "Date": "date-time"}
 

--- a/tap_exacttarget/streams/abstracts.py
+++ b/tap_exacttarget/streams/abstracts.py
@@ -3,6 +3,8 @@ from abc import ABC, abstractmethod
 from datetime import date, datetime, time, timedelta, timezone
 from typing import Any, Dict, List, Tuple
 
+from tap_exacttarget.exceptions import MarketingCloudError
+
 import dateutil.parser
 from singer import Transformer, get_bookmark, get_logger, write_bookmark, write_record
 from singer.metadata import get_standard_metadata, to_list, to_map, write
@@ -243,45 +245,83 @@ class IncrementalStream(BaseStream):
                 break
         return export_batches
 
+    def _build_search_filter(self, start_dt, end_dt, include_null=False):
+        """Build a date range search filter with optional null records."""
+        start_filter = self.client.create_simple_filter(
+            self.replication_key, "greaterThanOrEqual", date_value=start_dt
+        )
+        end_filter = self.client.create_simple_filter(
+            self.replication_key, "lessThanOrEqual", date_value=end_dt
+        )
+        search_filter = self.client.create_complex_filter(start_filter, "AND", end_filter)
+
+        if include_null:
+            null_filter = self.client.create_simple_filter(
+                self.replication_key, "isNull", value=None
+            )
+            search_filter = self.client.create_complex_filter(search_filter, "OR", null_filter)
+
+        return search_filter
+
+    def _fetch_paginated_records(self, query_fields, search_filter, start_dt, end_dt, include_null=False):
+        """Fetch records with pagination and null filter error retry logic."""
+        next_page = True
+        request_id = None
+
+        while next_page:
+            try:
+                response = self.client.retrieve_request(
+                    self.object_ref, query_fields, request_id=request_id, search_filter=search_filter
+                )
+            except MarketingCloudError as e:
+                if include_null and "Value cannot be null" in str(e):
+                    LOGGER.warning(
+                        "Query with isNull filter failed for %s, retrying without null filter.",
+                        self.object_ref,
+                    )
+                    search_filter = self._build_search_filter(start_dt, end_dt, include_null=False)
+                    response = self.client.retrieve_request(
+                        self.object_ref, query_fields, request_id=request_id, search_filter=search_filter
+                    )
+                else:
+                    raise
+
+            raw_records = response["Results"]
+            request_id = response["RequestID"]
+
+            if response["OverallStatus"] != "MoreDataAvailable":
+                if "Error" in response["OverallStatus"]:
+                    LOGGER.info(
+                        "Req Failed: %s %s %s",
+                        self.object_ref,
+                        query_fields,
+                        response["OverallStatus"],
+                    )
+                next_page = False
+
+            for rec in raw_records:
+                if (transformed := self.transform_record(rec)):
+                    yield transformed
+
     def get_records(self, start_date, stream_metadata, schema):
         """Performs Pagination and query building."""
-
+        fetch_null = True
         query_fields = self.get_query_fields(stream_metadata, schema)
         self.query_fields = query_fields
+
         for start_dt, end_dt in self.create_date_windows(
             start_date, now().astimezone(tz=fixed_cst), self.client.date_window
         ):
-            start_date = self.client.create_simple_filter(
-                self.replication_key, "greaterThanOrEqual", date_value=start_dt
-            )
-            end_date = self.client.create_simple_filter(
-                self.replication_key, "lessThanOrEqual", date_value=end_dt
-            )
-            date_range = self.client.create_complex_filter(start_date, "AND", end_date)
+            search_filter = self._build_search_filter(start_dt, end_dt, include_null=fetch_null)
 
-            next_page = True
-            request_id = None
-            while next_page:
+            for record in self._fetch_paginated_records(
+                query_fields, search_filter, start_dt, end_dt, include_null=fetch_null
+            ):
+                yield record
 
-                response = self.client.retrieve_request(
-                    self.object_ref, query_fields, request_id=request_id, search_filter=date_range
-                )
-                raw_records = response["Results"]
-                request_id = response["RequestID"]
-
-                if response["OverallStatus"] != "MoreDataAvailable":
-                    if "Error" in response["OverallStatus"]:
-                        LOGGER.info(
-                            "Req Failed: %s %s %s",
-                            self.object_ref,
-                            query_fields,
-                            response["OverallStatus"],
-                        )
-                    next_page = False
-
-                for rec in raw_records:
-                    if (transformed := self.transform_record(rec)):
-                        yield transformed
+            # Only include null filter on first window
+            if fetch_null:
+                fetch_null = False
 
     def sync(
         self, state: Dict, schema: Dict, stream_metadata: Dict, transformer: Transformer

--- a/tests/unittests/test_data_ext_discovery.py
+++ b/tests/unittests/test_data_ext_discovery.py
@@ -562,6 +562,36 @@ class TestDiscoverDaoStreams(unittest.TestCase):
         self.assertEqual(stream_class.replication_key, "ModifiedDate")
 
     @patch("tap_exacttarget.discover_dataextensionobj.discover_fields")
+    def test_replication_key_priority_event_datetime_first(self, mock_discover_fields):
+        mock_discover_fields.return_value = {
+            "customer-key-005-a": {
+                "key_properties": ["Id"],
+                "valid_replication_keys": [
+                    "ModifiedDate",
+                    "EventDate",
+                    "EventDateTime",
+                ],
+                "properties": {
+                    "Id": {"type": ["null", "integer"]},
+                    "ModifiedDate": {"type": ["null", "string"]},
+                    "EventDate": {"type": ["null", "string"]},
+                    "EventDateTime": {"type": ["null", "string"]},
+                },
+            }
+        }
+
+        mock_client = Mock()
+        mock_client.retrieve_request.return_value = {
+            "RequestID": "req-123",
+            "OverallStatus": "OK",
+            "Results": [{"CustomerKey": "customer-key-005-a", "Name": "EventExt", "CategoryID": 100}],
+        }
+
+        result = discover_dao_streams(mock_client)
+        stream_class = result["data_extension_eventext"]
+        self.assertEqual(stream_class.replication_key, "EventDateTime")
+
+    @patch("tap_exacttarget.discover_dataextensionobj.discover_fields")
     def test_replication_key_priority_join_date_second(self, mock_discover_fields):
         mock_discover_fields.return_value = {
             "customer-key-006": {

--- a/tests/unittests/test_data_ext_discovery.py
+++ b/tests/unittests/test_data_ext_discovery.py
@@ -569,13 +569,13 @@ class TestDiscoverDaoStreams(unittest.TestCase):
                 "valid_replication_keys": [
                     "ModifiedDate",
                     "EventDate",
-                    "EventDateTime",
+                    "EventDatetime",
                 ],
                 "properties": {
                     "Id": {"type": ["null", "integer"]},
                     "ModifiedDate": {"type": ["null", "string"]},
                     "EventDate": {"type": ["null", "string"]},
-                    "EventDateTime": {"type": ["null", "string"]},
+                    "EventDatetime": {"type": ["null", "string"]},
                 },
             }
         }

--- a/tests/unittests/test_data_ext_discovery.py
+++ b/tests/unittests/test_data_ext_discovery.py
@@ -589,7 +589,7 @@ class TestDiscoverDaoStreams(unittest.TestCase):
 
         result = discover_dao_streams(mock_client)
         stream_class = result["data_extension_eventext"]
-        self.assertEqual(stream_class.replication_key, "EventDateTime")
+        self.assertEqual(stream_class.replication_key, "EventDatetime")
 
     @patch("tap_exacttarget.discover_dataextensionobj.discover_fields")
     def test_replication_key_priority_join_date_second(self, mock_discover_fields):


### PR DESCRIPTION
# Description of change
- Updates supported replication keys to include EventDatetime and EventDate (the T in time is intentionally small as can be seen in the PR and the auto-discovered fields in the catalog)
- Add support for IsNull filter when querying data for all tables
- Fallback mechanism to disable null filter incase its not supported on the table

# Manual QA steps
 - 
 
# Risks
 - 
 
# Rollback steps
 - revert this branch

#### AI generated code
https://internal.qlik.dev/general/ways-of-working/code-reviews/#guidelines-for-ai-generated-code
- [ ] this PR has been written with the help of GitHub Copilot or another generative AI tool
